### PR TITLE
feat(deps): support laravel 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,15 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.0, 8.1, 8.2]
+        php: ["8.0", "8.1", "8.2", "8.3"]
+        laravel: ["^9.0", "^10.0", "^11.0"]
+        exclude:
+          - { php: "8.0", laravel: "^10.0"}
+          - { php: "8.0", laravel: "^11.0"}
+          - { php: "8.1", laravel: "^11.0"}
+          - { php: "8.3", laravel: "^9.0"}
 
-    name: PHP ${{ matrix.php }}
+    name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
 
     steps:
       - name: Checkout code
@@ -30,8 +36,11 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip
           coverage: none
 
+      - name: Set laravel version
+        run: composer require "laravel/framework=${{ matrix.laravel }}" --no-update --no-interaction --no-progress
+
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
         "ext-json": "*",
         "doctrine/dbal": "^2.6|^3.0",
         "goldspecdigital/oooas": "^2.7.1",
-        "laravel/framework": "5.8.*|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "laravel/framework": "5.8.*|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "phpdocumentor/reflection-docblock": "^5.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.3|^6.0|^7.0",
-        "phpunit/phpunit": "^9.5.13"
+        "orchestra/testbench": "^5.3|^6.0|^7.0|^8.0|^9.0",
+        "phpunit/phpunit": "^9.5.13|^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Builders/InfoBuilderTest.php
+++ b/tests/Builders/InfoBuilderTest.php
@@ -12,8 +12,8 @@ class InfoBuilderTest extends TestCase
     /**
      * @dataProvider providerBuildContact
      *
-     * @param  array  $config
-     * @param  array  $expected
+     * @param array $config
+     * @param array $expected
      * @return void
      */
     public function testBuildContact(array $config, array $expected): void
@@ -23,7 +23,7 @@ class InfoBuilderTest extends TestCase
         $this->assertSameAssociativeArray($expected, $info->toArray());
     }
 
-    public function providerBuildContact(): array
+    public static function providerBuildContact(): array
     {
         $common = [
             'title' => 'sample_title',
@@ -40,8 +40,8 @@ class InfoBuilderTest extends TestCase
                         'url' => 'sample_contact_url',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
                 array_merge($common, [
@@ -51,8 +51,8 @@ class InfoBuilderTest extends TestCase
                         'url' => 'sample_contact_url',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
             ],
@@ -63,8 +63,8 @@ class InfoBuilderTest extends TestCase
                         'url' => 'sample_contact_url',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
                 array_merge($common, [
@@ -73,8 +73,8 @@ class InfoBuilderTest extends TestCase
                         'url' => 'sample_contact_url',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
             ],
@@ -85,8 +85,8 @@ class InfoBuilderTest extends TestCase
                         'url' => 'sample_contact_url',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
                 array_merge($common, [
@@ -95,8 +95,8 @@ class InfoBuilderTest extends TestCase
                         'url' => 'sample_contact_url',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
             ],
@@ -107,8 +107,8 @@ class InfoBuilderTest extends TestCase
                         'email' => 'sample_contact_email',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
                 array_merge($common, [
@@ -117,22 +117,22 @@ class InfoBuilderTest extends TestCase
                         'email' => 'sample_contact_email',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
             ],
             'If Contact does not exist, the correct json can be output.' => [
                 array_merge($common, [
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
                 array_merge($common, [
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
             ],
@@ -140,14 +140,14 @@ class InfoBuilderTest extends TestCase
                 array_merge($common, [
                     'contact' => [],
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
                 array_merge($common, [
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
             ],
@@ -160,7 +160,7 @@ class InfoBuilderTest extends TestCase
                         'url' => 'sample_contact_url',
                     ],
                     'license' => [
-                        'url'=>'sample_license_url',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
                 array_merge($common, [
@@ -179,7 +179,7 @@ class InfoBuilderTest extends TestCase
                         'url' => 'sample_contact_url',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
+                        'name' => 'sample_license_name',
                     ],
                 ]),
                 array_merge($common, [
@@ -189,7 +189,7 @@ class InfoBuilderTest extends TestCase
                         'url' => 'sample_contact_url',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
+                        'name' => 'sample_license_name',
                     ],
                 ]),
             ],
@@ -236,8 +236,8 @@ class InfoBuilderTest extends TestCase
     /**
      * Assert equality as an associative array.
      *
-     * @param  array  $expected
-     * @param  array  $actual
+     * @param array $expected
+     * @param array $actual
      * @return void
      */
     protected function assertSameAssociativeArray(array $expected, array $actual): void

--- a/tests/Builders/SecurityBuilderTest.php
+++ b/tests/Builders/SecurityBuilderTest.php
@@ -100,13 +100,13 @@ class SecurityBuilderTest extends TestCase
             ->action('get');
 
         $openApi = OpenApi::create()
-        ->security($globalRequirement)
-        ->components($components)
-        ->paths(
-            PathItem::create()
-                ->route('/foo')
-                ->operations($operation)
-        );
+            ->security($globalRequirement)
+            ->components($components)
+            ->paths(
+                PathItem::create()
+                    ->route('/foo')
+                    ->operations($operation)
+            );
 
         self::assertSame([
             'paths' => [
@@ -175,13 +175,13 @@ class SecurityBuilderTest extends TestCase
         $operations = $operationsBuilder->build([$routeInfo]);
 
         $openApi = OpenApi::create()
-        ->security($globalRequirement)
-        ->components($components)
-        ->paths(
-            PathItem::create()
-                ->route('/foo')
-                ->operations(...$operations)
-        );
+            ->security($globalRequirement)
+            ->components($components)
+            ->paths(
+                PathItem::create()
+                    ->route('/foo')
+                    ->operations(...$operations)
+            );
 
         self::assertSame([
             'paths' => [

--- a/tests/Builders/ServersBuilderTest.php
+++ b/tests/Builders/ServersBuilderTest.php
@@ -12,8 +12,8 @@ class ServersBuilderTest extends TestCase
     /**
      * @dataProvider providerBuild
      *
-     * @param  array  $config
-     * @param  array  $expected
+     * @param array $config
+     * @param array $expected
      * @return void
      */
     public function testBuild(array $config, array $expected): void
@@ -23,7 +23,7 @@ class ServersBuilderTest extends TestCase
         $this->assertSameAssociativeArray($expected[0], $servers[0]->toArray());
     }
 
-    public function providerBuild(): array
+    public static function providerBuild(): array
     {
         return [
             'If the variables field does not exist, it is possible to output the correct json.' => [
@@ -129,8 +129,8 @@ class ServersBuilderTest extends TestCase
     /**
      * Assert equality as an associative array.
      *
-     * @param  array  $expected
-     * @param  array  $actual
+     * @param array $expected
+     * @param array $actual
      * @return void
      */
     protected function assertSameAssociativeArray(array $expected, array $actual): void

--- a/tests/Builders/TagsBuilderTest.php
+++ b/tests/Builders/TagsBuilderTest.php
@@ -12,8 +12,8 @@ class TagsBuilderTest extends TestCase
     /**
      * @dataProvider providerBuild
      *
-     * @param  array  $config
-     * @param  array  $expected
+     * @param array $config
+     * @param array $expected
      * @return void
      */
     public function testBuild(array $config, array $expected): void
@@ -23,7 +23,7 @@ class TagsBuilderTest extends TestCase
         $this->assertSameAssociativeArray($expected[0], $tags[0]->toArray());
     }
 
-    public function providerBuild(): array
+    public static function providerBuild(): array
     {
         return [
             'If the external docs do not exist, it can output the correct json.' => [
@@ -60,8 +60,8 @@ class TagsBuilderTest extends TestCase
     /**
      * Assert equality as an associative array.
      *
-     * @param  array  $expected
-     * @param  array  $actual
+     * @param array $expected
+     * @param array $actual
      * @return void
      */
     protected function assertSameAssociativeArray(array $expected, array $actual): void


### PR DESCRIPTION
# Support for Laravel 11 and CI Improvements 🚀

This pull request introduces support for Laravel 11 as well as enhancements to Continuous Integration (CI).

## Changes

- **Support for Laravel 11**: Added support for the newly released version of Laravel. 🆕
- **CI Enhancements**: Optimized continuous integration processes. 🛠️
- **PHP Version Expansion**: Added PHP 8.3 in addition to the already supported versions 8.0 to 8.2. 📈
- **Multi-Version Laravel Support**: Tests conducted on versions 9.x through 11.x. 🔄
- **Dependency Updates**:
  - **orchestral/testbench**: Upgraded to version 9.x required for Laravel 11. 📦
  - **phpunit/phpunit**: Upgraded to version 10 required by Testbench 9.x. 📦
- **Test Fixes**: Adapted to changes introduced by PHPUnit 10.0, particularly the deprecation of using non-static methods as data providers. ⚠️

No code modifications were made except for the deprecation in PHPUnit. All combinations of PHP and Laravel versions passed the tests without any issues. Results can be viewed here.

## Commits

@KentarouTakeda added 4 commits 2 months ago:
- 3aa48bb: Add the Laravel and PHP versions to be tested 🧪
- 69aed46: Use the latest version of actions/checkout 🔄
- 60fc8cd: Support PHPUnit 10 and fix deprecation 🛠️
- aced95e: Support Laravel 11 and add to CI 🆕

## Acknowledgments

I would like to thank KentarouTakeda for his initial contribution to the package. As the maintainer has been AFK for several months, I forked the project and incorporated the changes from KentarouTakeda in order to update this package. 🤝

Closes #112 & PRs: https://github.com/vyuldashev/laravel-openapi/pull/110, https://github.com/vyuldashev/laravel-openapi/pull/109

I look forward to your feedback and reviews. Thank you for your consideration. 🙏