### PR TITLE
Add memoization for build referencable schemas

### DIFF
--- a/src/Concerns/Referencable.php
+++ b/src/Concerns/Referencable.php
@@ -14,6 +14,8 @@ use Vyuldashev\LaravelOpenApi\Factories\SecuritySchemeFactory;
 
 trait Referencable
 {
+    static $buildReferencableSchemas = [];
+
     public static function ref(?string $objectId = null): Schema
     {
         $instance = app(static::class);
@@ -38,6 +40,6 @@ trait Referencable
             $baseRef = '#/components/securitySchemes/';
         }
 
-        return Schema::ref($baseRef.$instance->build()->objectId, $objectId);
+        return self::$buildReferencableSchemas[static::class . "_{$objectId}"] ??= Schema::ref($baseRef.$instance->build()->objectId, $objectId);
     }
 }

--- a/tests/Fixtures/ExampleSchema.php
+++ b/tests/Fixtures/ExampleSchema.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Vyuldashev\LaravelOpenApi\Tests\Fixtures;
+
+use GoldSpecDigital\ObjectOrientedOAS\Contracts\SchemaContract;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Schema;
+use Vyuldashev\LaravelOpenApi\Contracts\Reusable;
+use Vyuldashev\LaravelOpenApi\Factories\SchemaFactory;
+
+class ExampleSchema extends SchemaFactory implements Reusable
+{
+    public function build(): SchemaContract
+    {
+        return Schema::object('ExampleSchema')
+            ->properties(
+                Schema::string('example_string'),
+                Schema::integer('example_integer'),
+                Schema::boolean('example_boolean'),
+            );
+    }
+}

--- a/tests/MemoizationTest.php
+++ b/tests/MemoizationTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Vyuldashev\LaravelOpenApi\Tests;
+
+use Vyuldashev\LaravelOpenApi\Tests\Fixtures\ExampleSchema;
+
+class MemoizationTest extends TestCase
+{
+    public function testReferencableInstanceBuildOnce(): void
+    {
+        self::assertEquals($e1ObjectId = (new ExampleSchema)::ref('e1'), (new ExampleSchema)::ref('e1'));
+        self::assertNotEquals($e1ObjectId, (new ExampleSchema)::ref('e2'));
+    }
+}


### PR DESCRIPTION
###### TLDR
**Memoization for referencable schemas to limit required instance builds.**

> [!IMPORTANT]
> Related to discussion https://github.com/TartanLeGrand/laravel-openapi/discussions/29.

---

### User benefit
Although the majority of declared schema properties are trivial:
```PHP
public function build(): SchemaContract
{
    return Schema::object('ExampleObject')
        ->properties(
             Schema::string('example-string-prop')->nullable(),
             Schema::integer('example-id')->example(123),
             // ...
        )
}
```
sometimes more resource demanding actions are being taken, e.g. model-querying to get example values:
```PHP
Schema::integer('status_id')
    ->enum(Status::pluck('id'))
```
> [!NOTE]
> Another examples are:
>  * querying schema descriptions
>  * creating custom `Collection`s for `...->enum(...)`s
>  * accessing some other third-party services to achieve e.g. one of the above

Now, assuming we have a bit more popular `Schema` that is loaded in multiple other `Schema`s, e.g. a `UserSchema`, that is being also referenced with the same _objectId_ (`UserSchema::ref('user')`):
```PHP
// Parent A
class ParentASchema extends SchemaFactory implements Reusable
{
    public function build(): SchemaContract
    {
        return Schema::object('ParentA')
            ->properties(
                // ...
                UserSchema::ref('user'),
            );
    }
}

// Parent B
class ParentBSchema extends SchemaFactory implements Reusable
{
    public function build(): SchemaContract
    {
        return Schema::object('ParentB')
            ->properties(
                // ...
                UserSchema::ref('user'),
            );
    }
}
```

:warning: **The schema-component will be build every time per reference** :warning:

### Implementation Overview

```diff
diff --git a/src/Concerns/Referencable.php b/src/Concerns/Referencable.php
index fd36525..4dfb8fe 100644
--- a/src/Concerns/Referencable.php
+++ b/src/Concerns/Referencable.php
@@ -14,6 +14,8 @@ use Vyuldashev\LaravelOpenApi\Factories\SecuritySchemeFactory;
 
 trait Referencable
 {
+    static $buildReferencableSchemas = [];
+
     public static function ref(?string $objectId = null): Schema
     {
         $instance = app(static::class);
@@ -38,6 +40,6 @@ trait Referencable
             $baseRef = '#/components/securitySchemes/';
         }
 
-        return Schema::ref($baseRef.$instance->build()->objectId, $objectId);
+        return self::$buildReferencableSchemas[static::class . "_{$objectId}"] ??= Schema::ref($baseRef.$instance->build()->objectId, $objectId);
     }
 }
```

To make sure we're not re-building schema components of the same class and with the same object ID - we make use of the [Memoization Technique](https://en.wikipedia.org/wiki/Memoization).

### Test Overview
```PHP
class MemoizationTest extends TestCase
{
    public function testReferencableInstanceBuildOnce(): void
    {
        self::assertEquals($e1ObjectId = (new ExampleSchema)::ref('e1'), (new ExampleSchema)::ref('e1'));
        self::assertNotEquals($e1ObjectId, (new ExampleSchema)::ref('e2'));
    }
}
```

We test if objects of the same class and object ID are truly equal. Additionally - we make sure that the object ID matters in the second assertion. 