### PR TITLE
Feat: make the attribute instantiation more resistant to undefined attributes

### DIFF
--- a/src/RouteInformation.php
+++ b/src/RouteInformation.php
@@ -78,10 +78,12 @@ class RouteInformation
             $docBlock = $docComment ? DocBlockFactory::createInstance()->create($docComment) : null;
 
             $controllerAttributes = collect($reflectionClass->getAttributes())
-                ->map(fn (ReflectionAttribute $attribute) => $attribute->newInstance());
+                ->filter(fn(ReflectionAttribute $attribute) => class_exists($attribute->getName()))
+                ->map(fn(ReflectionAttribute $attribute) => $attribute->newInstance());
 
             $actionAttributes = collect($reflectionMethod->getAttributes())
-                ->map(fn (ReflectionAttribute $attribute) => $attribute->newInstance());
+                ->filter(fn(ReflectionAttribute $attribute) => class_exists($attribute->getName()))
+                ->map(fn(ReflectionAttribute $attribute) => $attribute->newInstance());
 
             $containsControllerLevelParamter = $actionAttributes->contains(fn ($value) => $value instanceof \Vyuldashev\LaravelOpenApi\Attributes\Parameters);
 


### PR DESCRIPTION
when using attributes on i.e. a Controller or Method that does not exist during generation of the open-api spec, the generation will fail with an error.

Attributes that are missing might be 
either some dev-dependency attributes that are stripped from the code base in production 
or some external attributes like the Deprecated - Attribute from PHPStorm


For me it was a big project with various controllers - many many with deprecations. when trying to integrate the laravel-openapi package it will fail due to missing class for Deprecated-Attribute when scanning all controllers.


by checking the existence of the attributes class before creating a new instance we can prevent this error from happening.