### PR TITLE
Fix: Make config cacheable

### DIFF
--- a/config/openapi.php
+++ b/config/openapi.php
@@ -31,7 +31,7 @@ return [
             ],
 
             'security' => [
-                // GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityRequirement::create()->securityScheme('JWT'),
+                // 'JWT',
             ],
 
             // Non standard attributes used by code/doc generation tools can be added here

--- a/docs/security.md
+++ b/docs/security.md
@@ -13,7 +13,7 @@ After you generate a security scheme, it will be declared in the `securityScheme
 ```php
 
 'security' => [
-  GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityRequirement::create()->securityScheme('BearerToken'),
+  'BearerToken',
 ],
 
 ```

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -50,13 +50,19 @@ class Generator
         $components = $this->componentsBuilder->build($collection, Arr::get($middlewares, 'components', []));
         $extensions = Arr::get($this->config, 'collections.'.$collection.'.extensions', []);
 
+        $securitySchemeNames = Arr::get($this->config, 'collections.'.$collection.'.security', []);
+        $securitySchemes = Arr::map(
+            $securitySchemeNames,
+            fn(string $name) => SecurityRequirement::create()->securityScheme($name)
+        );
+
         $openApi = OpenApi::create()
             ->openapi(OpenApi::OPENAPI_3_0_2)
             ->info($info)
             ->servers(...$servers)
             ->paths(...$paths)
             ->components($components)
-            ->security(...Arr::get($this->config, 'collections.'.$collection.'.security', []))
+            ->security(...$securitySchemes)
             ->tags(...$tags);
 
         foreach ($extensions as $key => $value) {

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -2,6 +2,7 @@
 
 namespace Vyuldashev\LaravelOpenApi;
 
+use GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityRequirement;
 use GoldSpecDigital\ObjectOrientedOAS\OpenApi;
 use Illuminate\Support\Arr;
 use Vyuldashev\LaravelOpenApi\Builders\ComponentsBuilder;


### PR DESCRIPTION
currently a call of

```
php artisan config:cache
```

or

```
php artisan optimize
```

will fail since in the config there are unserializable instances of SecurityRequirements

