### PR TITLE
chore(deps): Support PHP 8.5 and Laravel 13

### DIFF
--- a/.github/workflows/conventional-commits-check.yaml
+++ b/.github/workflows/conventional-commits-check.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check Commit Conventions
         uses: webiny/action-conventional-commits@v1.3.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: vuepress-deploy
       uses: jenkey2011/vuepress-deploy@master

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release Please Action
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: php

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,22 +15,26 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ["8.0", "8.1", "8.2", "8.3", "8.4"]
-        laravel: ["^9.0", "^10.0", "^11.0", "^12.0"]
+        php: ["8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
+        laravel: ["^9.0", "^10.0", "^11.0", "^12.0", "^13.0"]
         exclude:
           - { php: "8.0", laravel: "^10.0"}
           - { php: "8.0", laravel: "^11.0"}
           - { php: "8.0", laravel: "^12.0"}
+          - { php: "8.0", laravel: "^13.0"}
           - { php: "8.1", laravel: "^11.0"}
           - { php: "8.1", laravel: "^12.0"}
+          - { php: "8.1", laravel: "^13.0"}
+          - { php: "8.2", laravel: "^13.0"}
           - { php: "8.3", laravel: "^9.0"}
           - { php: "8.4", laravel: "^9.0"}
+          - { php: "8.5", laravel: "^9.0"}
 
     name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
         "php": "^8.0",
         "ext-json": "*",
         "goldspecdigital/oooas": "^2.7.1",
-        "laravel/framework": "^11.0|^12.0",
+        "laravel/framework": "^11.0|^12.0|^13.0",
         "phpdocumentor/reflection-docblock": "^5.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.3|^6.0|^7.0|^8.0|^9.0||^10",
+        "orchestra/testbench": "^5.3|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "phpunit/phpunit": "^9.5.13|^10.5||^11.5|^12.0"
     },
     "autoload": {

--- a/tests/Builders/InfoBuilderTest.php
+++ b/tests/Builders/InfoBuilderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Vyuldashev\LaravelOpenApi\Tests\Builders;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Vyuldashev\LaravelOpenApi\Builders\InfoBuilder;
 use Vyuldashev\LaravelOpenApi\Tests\TestCase;
 
@@ -16,6 +17,7 @@ class InfoBuilderTest extends TestCase
      * @param array $expected
      * @return void
      */
+    #[DataProvider('providerBuildContact')]
     public function testBuildContact(array $config, array $expected): void
     {
         $SUT = new InfoBuilder();

--- a/tests/Builders/ServersBuilderTest.php
+++ b/tests/Builders/ServersBuilderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Vyuldashev\LaravelOpenApi\Tests\Builders;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Vyuldashev\LaravelOpenApi\Builders\ServersBuilder;
 use Vyuldashev\LaravelOpenApi\Tests\TestCase;
 
@@ -16,6 +17,7 @@ class ServersBuilderTest extends TestCase
      * @param array $expected
      * @return void
      */
+    #[DataProvider('providerBuild')]
     public function testBuild(array $config, array $expected): void
     {
         $SUT = new ServersBuilder();

--- a/tests/Builders/TagsBuilderTest.php
+++ b/tests/Builders/TagsBuilderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Vyuldashev\LaravelOpenApi\Tests\Builders;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Vyuldashev\LaravelOpenApi\Builders\TagsBuilder;
 use Vyuldashev\LaravelOpenApi\Tests\TestCase;
 
@@ -16,6 +17,7 @@ class TagsBuilderTest extends TestCase
      * @param array $expected
      * @return void
      */
+    #[DataProvider('providerBuild')]
     public function testBuild(array $config, array $expected): void
     {
         $builder = new TagsBuilder();


### PR DESCRIPTION
This pull request provides:

- Support Laravel 13
- Add tests for PHP 8.5 to CI
- Update GitHub Actions to latest versions
  - `actions/checkout` v4 → v6
  - `release-please-action` migrate to `googleapis` org (archived `google-github-actions`)
